### PR TITLE
Implement flexible broadcast options

### DIFF
--- a/messages_file.py
+++ b/messages_file.py
@@ -121,6 +121,14 @@ MESSAGES = {
         "hy": "Рассылка выполнена.",
         "en": "Рассылка выполнена."
     },
+    "broadcast_invalid_percent": {
+        "hy": "Неверный процент. Укажите число от 1 до 100.",
+        "en": "Invalid percent value. Specify a number from 1 to 100."
+    },
+    "broadcast_invalid_ids": {
+        "hy": "Неверный список ID пользователей.",
+        "en": "Invalid user ID list."
+    },
     "order_date": {
         "hy": "Գործարքի ամսաթիվ",
         "en": "Order Date"


### PR DESCRIPTION
## Summary
- enhance `broadcast_message` function to support per-language messages
- allow admins to broadcast to a percentage or list of user IDs
- add error messages for invalid broadcast parameters

## Testing
- `python -m py_compile app.py messages_file.py`


------
https://chatgpt.com/codex/tasks/task_e_68641602c8e8832bad74b84e84139759